### PR TITLE
Use `py2opsin` to run OPSIN locally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ openpyxl = "^3.1.2"
 tqdm = "^4.66.1"
 urllib3 = "^2.0.6"
 xmltodict = "^0.13.0"
+py2opsin = "^1.1.0,<2.0.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This PR is in response to https://github.com/JacksonBurns/py2opsin/issues/25

This PR makes MoleculeResolver use `py2opsin` to convert molecules using OPSIN, rather than manually downloading OPSIN and calling it with `subprocess`.